### PR TITLE
fix: AArch64 ABI lowering for structs >16 bytes

### DIFF
--- a/modules/mmlc-lib/src/main/scala/mml/mmlclib/codegen/emitter/abis/aarch64/LargeStructIndirect.scala
+++ b/modules/mmlc-lib/src/main/scala/mml/mmlclib/codegen/emitter/abis/aarch64/LargeStructIndirect.scala
@@ -1,0 +1,34 @@
+package mml.mmlclib.codegen.emitter.abis.aarch64
+
+import mml.mmlclib.codegen.TargetAbi
+import mml.mmlclib.codegen.emitter.CodeGenState
+import mml.mmlclib.codegen.emitter.abis.{StructLoweringRule, isLargeStructAarch64}
+
+/** On AArch64, structs >16 bytes are passed indirectly via pointer (AAPCS64). */
+object LargeStructIndirect extends StructLoweringRule:
+  val targetAbi: TargetAbi = TargetAbi.AArch64
+
+  def lowerParamTypes(
+    structType: String,
+    fieldTypes: List[String]
+  ): Option[List[String]] =
+    if isLargeStructAarch64(fieldTypes) then Some(List("ptr"))
+    else None
+
+  def lowerArgs(
+    value:      String,
+    structType: String,
+    fieldTypes: List[String],
+    state:      CodeGenState
+  ): Option[(List[(String, String)], CodeGenState)] =
+    if isLargeStructAarch64(fieldTypes) then
+      val allocReg  = state.nextRegister
+      val allocLine = s"  %$allocReg = alloca $structType, align 8"
+      val storeReg  = state.nextRegister + 1
+      val storeLine = s"  store $structType $value, ptr %$allocReg, align 8"
+      val finalState = state
+        .withRegister(storeReg)
+        .emit(allocLine)
+        .emit(storeLine)
+      Some((List((s"%$allocReg", "ptr")), finalState))
+    else None


### PR DESCRIPTION
On AArch64 (AAPCS64), structs >16 bytes must be passed indirectly via pointer and returned via sret, matching clang's behavior. The MML compiler was passing these structs decomposed in registers, causing a SIGBUS when calling C runtime functions (e.g. unsafe_ar_int_set) that expected indirect pointer convention.

- Add LargeStructIndirect rule for AArch64 (alloca + store + pass ptr)
- Add isLargeStructAarch64 helper in AbiLowering
- Extend needsSretReturn to handle AArch64 (was x86_64-only)
- Update FunctionSignatureTest aarch64 assertions